### PR TITLE
Make README logo smaller

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Einstein Engines
 
-<p align="center"><img src="https://raw.githubusercontent.com/Simple-Station/Einstein-Engines/master/Resources/Textures/Logo/splashlogo.png" width="1080px" /></p>
+<p align="center"><img src="https://raw.githubusercontent.com/Simple-Station/Einstein-Engines/master/Resources/Textures/Logo/splashlogo.png" width="512px" /></p>
 
 ---
 


### PR DESCRIPTION
# Description

The logo in the README is very large and looks bad, this pr makes it smaller

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>
Old

![old](https://github.com/stellar-novas/Einstein-Engines/assets/158120145/5ff1b060-2e54-4ca9-bdf5-0cc5876ce07c)

New

![18:03:01](https://github.com/stellar-novas/Einstein-Engines/assets/158120145/731432b8-9e47-4c43-999b-d454b0137e60)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->
N/A
